### PR TITLE
ci: Remove Incorrect Dependency In Deploy Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    needs: build-and-test
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
- Accidentally left a dependency on the deploy action from the build
  and test action that I had split apart